### PR TITLE
add release actions file to build and publish docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,7 +1,8 @@
 name: Create and publish a Docker image
 
 on:
-  push:
+  release:
+    types: [published]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
I just use actions file from here: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-github-packages, but change build context path.
Each time you publish a release, github action will build and publish docker image to ghcr.io. In my case, image's name will be ghcr.io/mobikarl/stable-diffusion-webui-docker:release-name.
You can check my building process log over here: https://github.com/mobikarl/stable-diffusion-webui-docker/runs/8107076827.
Thank you for your hard work.
