### PR TITLE
preload models in lstein mount

### DIFF
--- a/services/lstein/mount.sh
+++ b/services/lstein/mount.sh
@@ -14,6 +14,9 @@ if test -f /cache/models/GFPGANv1.3.pth; then
   echo "Mounted GFPGANv1.3.pth"
 fi
 
+# Preload models. See https://github.com/lstein/stable-diffusion/issues/34
+python3 scripts/preload_models.py
+
 # facexlib
 FACEX_WEIGHTS=/opt/conda/lib/python3.8/site-packages/facexlib/weights
 


### PR DESCRIPTION
Fixes https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/72

For me that error occurs just by running `docker compose --profile lstein up --build`, so I'm not sure why you cannot reproduce this. However, I manually downloaded checkpoints to `cache/models`, and I'm using a custom `model.ckpt` file, not the official one. That might be the cause of the issue, but I'm not sure.

```console
non@anon-pc:~/Clones/stable-diffusion-webui-docker$ tree cache/models/
cache/models/
├── GFPGANv1.3.pth
├── LDSR.ckpt
├── LDSR.yaml
├── model.ckpt
├── RealESRGAN_x4plus_anime_6B.pth
└── RealESRGAN_x4plus.pth

0 directories, 6 files
```

I'll let you decide on whether you want to merge this.