### PR TITLE
Fix&Update to use lstein (PRELOAD=true)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,5 +53,5 @@ services:
     profiles: ["lstein"]
     build: ./services/lstein/
     environment:
-      - PRELOAD=false
+      - PRELOAD=true
       - CLI_ARGS=

--- a/services/lstein/mount.sh
+++ b/services/lstein/mount.sh
@@ -9,10 +9,11 @@ MOUNTS["/root/.cache"]=/data/.cache
 # ui specific
 MOUNTS["${PWD}/models/ldm/stable-diffusion-v1/model.ckpt"]=/data/StableDiffusion/model.ckpt
 MOUNTS["${PWD}/src/gfpgan/experiments/pretrained_models/GFPGANv1.4.pth"]=/data/GFPGAN/GFPGANv1.4.pth
-MOUNTS["${PWD}/ldm/invoke/restoration/codeformer/weights"]=/data/CodeFormer
+MOUNTS["${PWD}/ldm/invoke/restoration/codeformer/weights"]=/data/Codeformer
 # hacks
 MOUNTS["/opt/conda/lib/python3.9/site-packages/facexlib/weights"]=/data/.cache
 MOUNTS["/opt/conda/lib/python3.9/site-packages/realesrgan/weights"]=/data/RealESRGAN
+MOUNTS["${PWD}/gfpgan/weights"]=/data/GFPGAN/weights
 
 for to_path in "${!MOUNTS[@]}"; do
   set -Eeuo pipefail


### PR DESCRIPTION
1. Update `docker-compose.yml`: use `PRELOAD=true` for lstein. See the [note](https://github.com/invoke-ai/InvokeAI/blob/94bad8555a8832eca01ed7da6797f65cf6bb9cfb/docs/installation/INSTALL_LINUX.md?plain=1#L60) in the installation guide of InvokeAI.
3. Fix `services/lstein/mount.sh`: change `CodeFormer` to `Codeformer`.
4. Update `services/lstein/mount.sh`: avoid having to re-download the `${PWD}/gfpgan/weights/...` every time the container is started.

### Update versions

- lstein: https://github.com/invoke-ai/InvokeAI/commit/cac3f5fc61e6e380b090ac9a3fcda733a22f65a7
