### PR TITLE
mount styles.csv for auto

### DIFF
--- a/services/AUTOMATIC1111/mount.sh
+++ b/services/AUTOMATIC1111/mount.sh
@@ -10,6 +10,10 @@ if [ ! -f /data/config/auto/ui-config.json ]; then
   echo '{}' >/data/config/auto/ui-config.json
 fi
 
+if [ ! -f /data/config/auto/styles.csv ]; then
+  echo $'name,prompt,negative_prompt\nNone,,' >/data/config/auto/styles.csv
+fi
+
 declare -A MOUNTS
 
 MOUNTS["/root/.cache"]="/data/.cache"

--- a/services/AUTOMATIC1111/mount.sh
+++ b/services/AUTOMATIC1111/mount.sh
@@ -29,6 +29,7 @@ MOUNTS["${ROOT}/models/hypernetworks"]="/data/Hypernetworks"
 MOUNTS["${ROOT}/embeddings"]="/data/embeddings"
 MOUNTS["${ROOT}/config.json"]="/data/config/auto/config.json"
 MOUNTS["${ROOT}/ui-config.json"]="/data/config/auto/ui-config.json"
+MOUNTS["${ROOT}/styles.csv"]="/data/config/auto/styles.csv"
 
 # extra hacks
 MOUNTS["${ROOT}/repositories/CodeFormer/weights/facelib"]="/data/.cache"


### PR DESCRIPTION
persists styles saved with auto's ui - previous to this change, the saved styles were lost on container rebuild
