### PR TITLE
New `Dockerfile` arguments for the Stable diffusion Web UI (`auto`): custom `TORCH_COMMAND` and  additional APT `DEPENDENCIES` 

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -36,7 +36,8 @@ ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1 PIP_NO_CACHE_DIR=1
 
 ARG TORCH_COMMAND="pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
 RUN ${TORCH_COMMAND}
-RUN apt-get update && apt install fonts-dejavu-core rsync git jq moreutils -y && apt-get clean
+ARG DEPENDENCIES=""
+RUN apt-get update && apt install fonts-dejavu-core rsync git jq moreutils ${DEPENDENCIES} -y && apt-get clean
 
 
 RUN <<EOF

--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -34,8 +34,8 @@ SHELL ["/bin/bash", "-ceuxo", "pipefail"]
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1 PIP_NO_CACHE_DIR=1
 
-RUN pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
-
+ARG TORCH_COMMAND="pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113"
+RUN ${TORCH_COMMAND}
 RUN apt-get update && apt install fonts-dejavu-core rsync git jq moreutils -y && apt-get clean
 
 


### PR DESCRIPTION
Closes issue https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/218

To support installation of the [Dreambooth extension](https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/218) a user need to create the `docker-compose.override.yml` file with content:

```yaml
services:
  auto:
    build:
      args:
        # Override `TORCH_COMMAND`
        TORCH_COMMAND: "pip install torch==1.12.1+cu116 torchvision==0.13.1+cu116 --extra-index-url https://download.pytorch.org/whl/cu116"
        # Additional packages for the `apt install`
        DEPENDENCIES: "gcc"
    environment:
      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access
```

And then run:

```
docker compose --profile auto up
```
