### PR TITLE
RFC: Allow overrding torch libs from /data

### DIFF
--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -62,4 +62,10 @@ if [ -f "/data/config/auto/startup.sh" ]; then
   popd
 fi
 
+# Override cudnn lib files from /data/cudnn
+if [ -f "/data/cudnn/libcudnn.so.8" ]; then
+  PYTORCH_PATH=$(python -c "import torch; print(torch.__path__[0])")
+  cp /data/cudnn/lib* "$PYTORCH_PATH"/lib/
+fi
+
 exec "$@"


### PR DESCRIPTION
This is so you can copy the latest cudnn files (you have to extract them from a deb inside a deb from e.g. [1], haven't scripted that part yet)

References:
[1] https://developer.download.nvidia.com/compute/redist/cudnn/v8.8.0/local_installers/11.8/cudnn-local-repo-ubuntu2204-8.8.0.121_1.0-1_amd64.deb

I've added some discussion here:

https://github.com/AbdBarho/stable-diffusion-webui-docker/discussions/300

And I'm not sure this is the best way of overriding libs

<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Closes issue #

### Update versions

- auto: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/
- sygil: https://github.com/Sygil-Dev/sygil-webui/commit/
- invoke: https://github.com/invoke-ai/InvokeAI/commit/
