### PR TITLE
Add option to set the docker user ID and group ID to the current user

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3.9'
 
 x-base_service: &base_service
+    user: "${USER_ID:-0:0}"
     ports:
       - "7860:7860"
     volumes:

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+ if [ "$#" -ne  "1" ]
+   then
+     echo "usage: $ ./run.sh [ download | auto | auto-cpu | invoke | sygil | sygil-sl ]"
+ else
+     USER_ID=$(id -u):$(id -g) docker compose --profile $1 up --build
+ fi


### PR DESCRIPTION
<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Closes issue #
Discussions: Consider run service as non-root user. 

Add the user ID to the service template:
```
x-base_service: &base_service
    user: "${USER_ID:-0:0}"
```

And add a new `run.sh` script that enforce the user ID on the dockers:
```
#!/bin/bash
 if [ "$#" -ne  "1" ]
   then
     echo "usage: $ ./run.sh [ download | auto | auto-cpu | invoke | sygil | sygil-sl ]"
 else
     USER_ID=$(id -u):$(id -g) docker compose --profile $1 up --build
 fi
```
If the `docker compose` runs without the script, it will work with user ID 0:0