### PR TITLE
enable ControlNet mounts for AUTOMATIC1111

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -20,3 +20,4 @@
 /VAE
 /embeddings
 /Lora
+/ControlNet

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     <<: *base_service
     profiles: ["auto"]
     build: ./services/AUTOMATIC1111
-    image: sd-auto:49
+    image: sd-auto:50
     environment:
       - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
 

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -35,6 +35,7 @@ MOUNTS["${ROOT}/models/torch_deepdanbooru"]="/data/Deepdanbooru"
 MOUNTS["${ROOT}/models/BLIP"]="/data/BLIP"
 MOUNTS["${ROOT}/models/midas"]="/data/MiDaS"
 MOUNTS["${ROOT}/models/Lora"]="/data/Lora"
+MOUNTS["${ROOT}/models/ControlNet"]="/data/ControlNet"
 
 MOUNTS["${ROOT}/embeddings"]="/data/embeddings"
 MOUNTS["${ROOT}/config.json"]="/data/config/auto/config.json"

--- a/services/download/download.sh
+++ b/services/download/download.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 # TODO: maybe just use the .gitignore file to create all of these
-mkdir -vp /data/.cache /data/StableDiffusion /data/Codeformer /data/GFPGAN /data/ESRGAN /data/BSRGAN /data/RealESRGAN /data/SwinIR /data/LDSR /data/ScuNET /data/embeddings /data/VAE /data/Deepdanbooru /data/MiDaS /data/Lora
+mkdir -vp /data/.cache /data/StableDiffusion /data/Codeformer /data/GFPGAN /data/ESRGAN /data/BSRGAN /data/RealESRGAN /data/SwinIR /data/LDSR /data/ScuNET /data/embeddings /data/VAE /data/Deepdanbooru /data/MiDaS /data/Lora /data/ControlNet
 
 echo "Downloading, this might take a while..."
 


### PR DESCRIPTION
The ControlNet addon [sd-webui-controlnet](https://github.com/Mikubill/sd-webui-controlnet) requires the `data/ControlNet` folder to be mounted into `models/ControlNet`.
This PR enables said mount and adds the ControlNet folder to `.gitignore` file.
