### PR TITLE
add mounts for openpose

### DIFF
--- a/data/.gitignore
+++ b/data/.gitignore
@@ -20,3 +20,4 @@
 /VAE
 /embeddings
 /Lora
+/openpose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
     <<: *base_service
     profiles: ["auto"]
     build: ./services/AUTOMATIC1111
-    image: sd-auto:50
+    image: sd-auto:51
     environment:
       - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
 

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -35,6 +35,7 @@ MOUNTS["${ROOT}/models/torch_deepdanbooru"]="/data/Deepdanbooru"
 MOUNTS["${ROOT}/models/BLIP"]="/data/BLIP"
 MOUNTS["${ROOT}/models/midas"]="/data/MiDaS"
 MOUNTS["${ROOT}/models/Lora"]="/data/Lora"
+MOUNTS["${ROOT}/models/openpose"]="/data/openpose"
 
 MOUNTS["${ROOT}/embeddings"]="/data/embeddings"
 MOUNTS["${ROOT}/config.json"]="/data/config/auto/config.json"

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -38,7 +38,6 @@ MOUNTS["${ROOT}/models/Lora"]="/data/Lora"
 MOUNTS["${ROOT}/models/ControlNet"]="/data/ControlNet"
 MOUNTS["${ROOT}/models/openpose"]="/data/openpose"
 
-
 MOUNTS["${ROOT}/embeddings"]="/data/embeddings"
 MOUNTS["${ROOT}/config.json"]="/data/config/auto/config.json"
 MOUNTS["${ROOT}/ui-config.json"]="/data/config/auto/ui-config.json"

--- a/services/download/download.sh
+++ b/services/download/download.sh
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 # TODO: maybe just use the .gitignore file to create all of these
-mkdir -vp /data/.cache /data/StableDiffusion /data/Codeformer /data/GFPGAN /data/ESRGAN /data/BSRGAN /data/RealESRGAN /data/SwinIR /data/LDSR /data/ScuNET /data/embeddings /data/VAE /data/Deepdanbooru /data/MiDaS /data/Lora
+mkdir -vp /data/.cache /data/StableDiffusion /data/Codeformer /data/GFPGAN /data/ESRGAN /data/BSRGAN /data/RealESRGAN /data/SwinIR /data/LDSR /data/ScuNET /data/embeddings /data/VAE /data/Deepdanbooru /data/MiDaS /data/Lora /data/openpose
 
 echo "Downloading, this might take a while..."
 


### PR DESCRIPTION
Upon enabling the ControlNet addon from https://github.com/AbdBarho/stable-diffusion-webui-docker/pull/385 one might want to use the `openpose` preprocessors. Those are downloaded by the addon the first time they are used. Without proper mounts those networks will be downloaded on usage after each container start.
This PR enables those mounts to reduce data traffic.