### PR TITLE
Make Dockerfiles OCI compliant

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,11 +15,6 @@ x-base_service: &base_service
                 device_ids: ['0']
                 capabilities: [gpu]
 
-x-gpu-config: &gpu_config
-    security_opt:
-      - label=type:nvidia_container_t
-    runtime: nvidia
-
 name: webui-docker
 
 services:
@@ -29,25 +24,23 @@ services:
     volumes:
       - *v1
 
-  auto-cpu: &automatic
+  auto: &automatic
     <<: *base_service
-    profiles: ["auto-cpu"]
+    profiles: ["auto"]
     build: ./services/AUTOMATIC1111
     image: sd-auto:51
     environment:
-      - CLI_ARGS=--no-half --precision full --allow-code --enable-insecure-extension-access --api
+      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
 
-  auto:
+  auto-cpu:
     <<: *automatic
-    <<: *gpu_config
-    profiles: ["auto"]
+    profiles: ["auto-cpu"]
     deploy: {}
     environment:
-      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
+      - CLI_ARGS=--no-half --precision full --allow-code --enable-insecure-extension-access --api
 
   invoke:
     <<: *base_service
-    <<: *gpu_config
     profiles: ["invoke"]
     build: ./services/invoke/
     image: sd-invoke:26
@@ -58,7 +51,6 @@ services:
 
   sygil: &sygil
     <<: *base_service
-    <<: *gpu_config
     profiles: ["sygil"]
     build: ./services/sygil/
     image: sd-sygil:16

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,9 @@ x-base_service: &base_service
       - &v1 ./data:/data
       - &v2 ./output:/output
     stop_signal: SIGINT
+    security_opt:
+      - label=type:nvidia_container_t
+    runtime: nvidia
     deploy:
       resources:
         reservations:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,6 @@ x-base_service: &base_service
       - &v1 ./data:/data
       - &v2 ./output:/output
     stop_signal: SIGINT
-    security_opt:
-      - label=type:nvidia_container_t
-    runtime: nvidia
     deploy:
       resources:
         reservations:
@@ -17,6 +14,11 @@ x-base_service: &base_service
               - driver: nvidia
                 device_ids: ['0']
                 capabilities: [gpu]
+
+x-gpu-config: &gpu_config
+    security_opt:
+      - label=type:nvidia_container_t
+    runtime: nvidia
 
 name: webui-docker
 
@@ -27,23 +29,25 @@ services:
     volumes:
       - *v1
 
-  auto: &automatic
+  auto-cpu: &automatic
     <<: *base_service
-    profiles: ["auto"]
+    profiles: ["auto-cpu"]
     build: ./services/AUTOMATIC1111
     image: sd-auto:51
     environment:
-      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
+      - CLI_ARGS=--no-half --precision full --allow-code --enable-insecure-extension-access --api
 
-  auto-cpu:
+  auto:
     <<: *automatic
-    profiles: ["auto-cpu"]
+    <<: *gpu_config
+    profiles: ["auto"]
     deploy: {}
     environment:
-      - CLI_ARGS=--no-half --precision full --allow-code --enable-insecure-extension-access --api
+      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
 
   invoke:
     <<: *base_service
+    <<: *gpu_config
     profiles: ["invoke"]
     build: ./services/invoke/
     image: sd-invoke:26
@@ -54,6 +58,7 @@ services:
 
   sygil: &sygil
     <<: *base_service
+    <<: *gpu_config
     profiles: ["sygil"]
     build: ./services/sygil/
     image: sd-sygil:16

--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -1,14 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine/git:2.36.2 as download
+FROM alpine:3.17 as download
 
-SHELL ["/bin/sh", "-ceuxo", "pipefail"]
+RUN apk add git
 
-RUN <<EOF
-cat <<'EOE' > /clone.sh
-mkdir -p repositories/"$1" && cd repositories/"$1" && git init && git remote add origin "$2" && git fetch origin "$3" --depth=1 && git reset --hard "$3" && rm -rf .git
-EOE
-EOF
+COPY clone.sh /clone.sh
 
 RUN . /clone.sh taming-transformers https://github.com/CompVis/taming-transformers.git 24268930bf1dce879235a7fddd0b2355b84d7ea6 \
   && rm -rf data assets **/*.ipynb
@@ -30,8 +26,6 @@ RUN aria2c -x 5 --dir / --out wheel.whl 'https://github.com/AbdBarho/stable-diff
 
 FROM python:3.10.9-slim
 
-SHELL ["/bin/bash", "-ceuxo", "pipefail"]
-
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
 
 RUN PIP_NO_CACHE_DIR=1 pip install torch==1.13.1+cu117 torchvision --extra-index-url https://download.pytorch.org/whl/cu117
@@ -39,12 +33,11 @@ RUN PIP_NO_CACHE_DIR=1 pip install torch==1.13.1+cu117 torchvision --extra-index
 RUN apt-get update && apt install fonts-dejavu-core rsync git jq moreutils -y && apt-get clean
 
 
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui.git
-cd stable-diffusion-webui
-git reset --hard d7aec59c4eb02f723b3d55c6f927a42e97acd679
-pip install -r requirements_versions.txt
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui.git && \
+  cd stable-diffusion-webui && \
+  git reset --hard d7aec59c4eb02f723b3d55c6f927a42e97acd679 && \
+  pip install -r requirements_versions.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip  \
   --mount=type=bind,from=xformers,source=/wheel.whl,target=/xformers-0.0.15-cp310-cp310-linux_x86_64.whl \
@@ -72,25 +65,25 @@ RUN apt-get -y install libgoogle-perftools-dev && apt-get clean
 ENV LD_PRELOAD=libtcmalloc.so
 
 ARG SHA=a9fed7c364061ae6efb37f797b6b522cb3cf7aa2
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-cd stable-diffusion-webui
-git fetch
-git reset --hard ${SHA}
-pip install -r requirements_versions.txt
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  cd stable-diffusion-webui && \
+  git fetch && \
+  git reset --hard ${SHA} && \
+  pip install -r requirements_versions.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip  pip install -U opencv-python-headless
 
 COPY . /docker
 
-RUN <<EOF
-python3 /docker/info.py ${ROOT}/modules/ui.py
-mv ${ROOT}/style.css ${ROOT}/user.css
-# one of the ugliest hacks I ever wrote
-sed -i 's/in_app_dir = .*/in_app_dir = True/g' /usr/local/lib/python3.10/site-packages/gradio/routes.py
-EOF
+RUN \
+  python3 /docker/info.py ${ROOT}/modules/ui.py && \
+  mv ${ROOT}/style.css ${ROOT}/user.css && \
+  # one of the ugliest hacks I ever wrote \
+  sed -i 's/in_app_dir = .*/in_app_dir = True/g' /usr/local/lib/python3.10/site-packages/gradio/routes.py
 
 WORKDIR ${ROOT}
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
 ENV CLI_ARGS=""
 EXPOSE 7860
 ENTRYPOINT ["/docker/entrypoint.sh"]

--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 FROM alpine/git:2.36.2 as download
 
 COPY clone.sh /clone.sh
@@ -26,7 +24,8 @@ FROM python:3.10.9-slim
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
 
-RUN PIP_NO_CACHE_DIR=1 pip install torch==1.13.1+cu117 torchvision --extra-index-url https://download.pytorch.org/whl/cu117
+RUN --mount=type=cache,target=/root/.cache/pip \
+  pip install torch==1.13.1+cu117 torchvision --extra-index-url https://download.pytorch.org/whl/cu117
 
 RUN apt-get update && apt install fonts-dejavu-core rsync git jq moreutils -y && apt-get clean
 

--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -1,8 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.17 as download
-
-RUN apk add git
+FROM alpine/git:2.36.2 as download
 
 COPY clone.sh /clone.sh
 
@@ -46,7 +44,7 @@ RUN --mount=type=cache,target=/root/.cache/pip  \
 ENV ROOT=/stable-diffusion-webui
 
 
-COPY --from=download /git/ ${ROOT}
+COPY --from=download /repositories/ ${ROOT}/repositories/
 RUN mkdir ${ROOT}/interrogate && cp ${ROOT}/repositories/clip-interrogator/data/* ${ROOT}/interrogate
 RUN --mount=type=cache,target=/root/.cache/pip \
   pip install -r ${ROOT}/repositories/CodeFormer/requirements.txt

--- a/services/AUTOMATIC1111/clone.sh
+++ b/services/AUTOMATIC1111/clone.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+mkdir -p git/repositories/"$1"
+cd git/repositories/"$1"
+git init
+git remote add origin "$2"
+git fetch origin "$3" --depth=1
+git reset --hard "$3"
+rm -rf .git

--- a/services/AUTOMATIC1111/clone.sh
+++ b/services/AUTOMATIC1111/clone.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-set -Eeuo pipefail
+set -Eeuox pipefail
 
-mkdir -p git/repositories/"$1"
-cd git/repositories/"$1"
+mkdir -p /repositories/"$1"
+cd /repositories/"$1"
 git init
 git remote add origin "$2"
 git fetch origin "$3" --depth=1

--- a/services/invoke/Dockerfile
+++ b/services/invoke/Dockerfile
@@ -7,7 +7,6 @@ RUN aria2c -x 5 --dir / --out wheel.whl 'https://github.com/AbdBarho/stable-diff
 
 
 FROM python:3.10-slim
-SHELL ["/bin/bash", "-ceuxo", "pipefail"]
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_EXISTS_ACTION=w  PIP_PREFER_BINARY=1
 
@@ -20,35 +19,32 @@ RUN git clone https://github.com/invoke-ai/InvokeAI.git /stable-diffusion
 
 WORKDIR /stable-diffusion
 
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-git reset --hard f232068ab89bd80e4f5f3133dcdb62ea78f1d0f7
-git config --global http.postBuffer 1048576000
-egrep -v '^-e .' environments-and-requirements/requirements-lin-cuda.txt > req.txt
-pip install -r req.txt
-rm req.txt
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  git reset --hard f232068ab89bd80e4f5f3133dcdb62ea78f1d0f7 && \
+  git config --global http.postBuffer 1048576000 && \
+  egrep -v '^-e .' environments-and-requirements/requirements-lin-cuda.txt > req.txt && \
+  pip install -r req.txt && \
+  rm req.txt
 
 
 # patch match:
 # https://github.com/invoke-ai/InvokeAI/blob/main/docs/installation/INSTALL_PATCHMATCH.md
-RUN <<EOF
-apt-get update
-# apt-get install build-essential python3-opencv libopencv-dev -y
-apt-get install make g++ libopencv-dev -y
-apt-get clean
-cd /usr/lib/x86_64-linux-gnu/pkgconfig/
-ln -sf opencv4.pc opencv.pc
-EOF
+RUN \
+  apt-get update && \
+  # apt-get install build-essential python3-opencv libopencv-dev -y && \
+  apt-get install make g++ libopencv-dev -y && \
+  apt-get clean && \
+  cd /usr/lib/x86_64-linux-gnu/pkgconfig/ && \
+  ln -sf opencv4.pc opencv.pc
 
 
 ARG BRANCH=main SHA=6e0c6d9cc9f6bdbdefc4b9e94bc1ccde1b04aa42
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-git fetch
-git reset --hard
-git checkout ${BRANCH}
-git reset --hard ${SHA}
-pip install .
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  git fetch && \
+  git reset --hard && \
+  git checkout ${BRANCH} && \
+  git reset --hard ${SHA} && \
+  pip install .
 
 
 RUN --mount=type=cache,target=/root/.cache/pip \
@@ -60,7 +56,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 RUN touch invokeai.init
 COPY . /docker/
 
-
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
 ENV PYTHONUNBUFFERED=1 ROOT=/stable-diffusion PYTHONPATH="${PYTHONPATH}:${ROOT}" PRELOAD=false CLI_ARGS="" HF_HOME=/root/.cache/huggingface
 EXPOSE 7860
 

--- a/services/invoke/Dockerfile
+++ b/services/invoke/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 FROM alpine:3.17 as xformers
 RUN apk add --no-cache aria2
 RUN aria2c -x 5 --dir / --out wheel.whl 'https://github.com/AbdBarho/stable-diffusion-webui-docker/releases/download/5.0.0/xformers-0.0.17.dev449-cp310-cp310-manylinux2014_x86_64.whl'

--- a/services/sygil/Dockerfile
+++ b/services/sygil/Dockerfile
@@ -2,44 +2,41 @@
 
 FROM python:3.8-slim
 
-SHELL ["/bin/bash", "-ceuxo", "pipefail"]
-
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install torch==1.13.0 torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu117
 
 RUN apt-get update && apt install gcc libsndfile1 ffmpeg build-essential zip unzip git -y && apt-get clean
 
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-git config --global http.postBuffer 1048576000
-git clone https://github.com/Sygil-Dev/sygil-webui.git stable-diffusion
-cd stable-diffusion
-git reset --hard 5291437085bddd16d752f811b6552419a2044d12
-pip install -r requirements.txt
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  git config --global http.postBuffer 1048576000 && \
+  git clone https://github.com/Sygil-Dev/sygil-webui.git stable-diffusion && \
+  cd stable-diffusion && \
+  git reset --hard 5291437085bddd16d752f811b6552419a2044d12 && \
+  pip install -r requirements.txt
 
 
 ARG BRANCH=master SHA=571fb897edd58b714bb385dfaa1ad59aecef8bc7
-RUN --mount=type=cache,target=/root/.cache/pip <<EOF
-cd stable-diffusion
-git fetch
-git checkout ${BRANCH}
-git reset --hard ${SHA}
-pip install -r requirements.txt
-EOF
+RUN --mount=type=cache,target=/root/.cache/pip \
+  cd stable-diffusion && \
+  git fetch && \
+  git checkout ${BRANCH} && \
+  git reset --hard ${SHA} && \
+  pip install -r requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install -U 'transformers>=4.24'
 
 # add info
 COPY . /docker/
-RUN <<EOF
-python /docker/info.py /stable-diffusion/frontend/frontend.py
-chmod +x /docker/mount.sh /docker/run.sh
-# streamlit
-sed -i -- 's/8501/7860/g' /stable-diffusion/.streamlit/config.toml
-EOF
+RUN \
+  python /docker/info.py /stable-diffusion/frontend/frontend.py && \
+  chmod +x /docker/mount.sh /docker/run.sh && \
+  # streamlit \
+  sed -i -- 's/8501/7860/g' /stable-diffusion/.streamlit/config.toml
 
 WORKDIR /stable-diffusion
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+ENV NVIDIA_VISIBLE_DEVICES=all
 ENV PYTHONPATH="${PYTHONPATH}:${PWD}" STREAMLIT_SERVER_HEADLESS=true USE_STREAMLIT=0 CLI_ARGS=""
 EXPOSE 7860
 

--- a/services/sygil/Dockerfile
+++ b/services/sygil/Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:1
-
 FROM python:3.8-slim
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
@@ -28,8 +26,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip install -U 'transformers>=4.2
 
 # add info
 COPY . /docker/
-RUN \
-  python /docker/info.py /stable-diffusion/frontend/frontend.py && \
+RUN python /docker/info.py /stable-diffusion/frontend/frontend.py && \
   chmod +x /docker/mount.sh /docker/run.sh && \
   # streamlit \
   sed -i -- 's/8501/7860/g' /stable-diffusion/.streamlit/config.toml


### PR DESCRIPTION
## Justification

Closes issue #352

This update makes the Dockerfiles OCI compliant, making it easier to use Buildah or other image building techniques that require it

## Implementation

This changes a few things, listed below:

* auto: Download container is switched to alpine. The `git` container specified the `/git` directory as a volume. As such, all the files under `/git` would be lost after each script invoke. Alpine is used later in the build process anyway, so it shouldn't be any extra cost to switch to it
* auto: "New" clone.sh script is copied into the container, which is basically just the previous clone script that was embedded in the Dockerfile. 
* all: `<<EOF` heredoc styles have been switched to `&& \`
* all: I added NVIDIA_DRIVER_CAPABILITIES and NVIDIA_VISIBLE_DEVICES to expose my Nvidia card. This is most likely a selinux/podman problem, but shouldn't change anything with docker to add it.
* docker-compose: I added selinux labeling. I tested this with real docker (not just podman!) and it seems to work fine. Though I suggest you try it too.

## Testing

Locally builds with buildah. 

Note: for caching to work properly, you still need to replace `/root/.cache/pip` with `/root/.cache/pip,Z` on selinux systems.

Note: I was having some trouble running invoke. Thought it was this PR, but it's a known issue. See https://github.com/invoke-ai/InvokeAI/issues/3182

