### PR TITLE
Fix overwriting existing values in config.json in auto

### DIFF
--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -9,7 +9,7 @@ find "${ROOT}/scripts/" -maxdepth 1 -type l -delete
 cp -vrfTs /data/config/auto/scripts/ "${ROOT}/scripts/"
 
 cp -n /docker/config.json /data/config/auto/config.json
-jq '. * input' /data/config/auto/config.json /docker/config.json | sponge /data/config/auto/config.json
+jq '. * input' /docker/config.json /data/config/auto/config.json | sponge /data/config/auto/config.json
 
 if [ ! -f /data/config/auto/ui-config.json ]; then
   echo '{}' >/data/config/auto/ui-config.json


### PR DESCRIPTION
`jq` merge direction in this case is right to left so if the user had set up custom paths it would replace them with the default ones. 

This PR switches the direction to use the defaults as fallback instead of overwriting user settings.

----

Didn't want to create an issue for the tiny change.

Thanks for your work on the repo, it saved me a lot of time, 👍 