### PR TITLE
Add dependencies for Deforum extension

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -80,6 +80,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 COPY . /docker
 
+RUN pip install rich
+RUN pip install numexpr
+RUN pip install python-dotenv
+RUN pip install segno
+
 RUN \
   python3 /docker/info.py ${ROOT}/modules/ui.py && \
   mv ${ROOT}/style.css ${ROOT}/user.css && \


### PR DESCRIPTION
Deforum is a popular automatic1111 extension, this addition adds the needed dependencies so it can work properly with this docker image!

Sorry I'm not a docker expert so I just added the lines in a way that worked here when testing, idk if this is the best place to install these dependencies!