### PR TITLE
Modify installation extension dependencies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     <<: *base_service
     profiles: ["auto"]
     build: ./services/AUTOMATIC1111
-    image: sd-auto:59
+    image: sd-auto:60
     environment:
       - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
 

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -57,9 +57,9 @@ chown -R root ~/.cache/
 chmod 766 ~/.cache/
 
 shopt -s nullglob
-list=(./extensions/*/requirements.txt)
-for req in "${list[@]}"; do
-  pip install -r "$req"
+list=(./extensions/*/install.py)
+for installscript in "${list[@]}"; do
+  PYTHONPATH=${ROOT} python "$installscript"
 done
 
 if [ -f "/data/config/auto/startup.sh" ]; then

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -57,6 +57,7 @@ chown -R root ~/.cache/
 chmod 766 ~/.cache/
 
 shopt -s nullglob
+# For install.py, please refer to https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Developing-extensions#installpy
 list=(./extensions/*/install.py)
 for installscript in "${list[@]}"; do
   PYTHONPATH=${ROOT} python "$installscript"


### PR DESCRIPTION
Perform a full extension installation process instead of just installing dependencies
Some extensions do not include `requirements.txt` but install dependencies in `install.py`, and all extensions include `install.py`, so it is safe to use it for extended dependency installation
This is because the extension development of AUTOMATIC1111's webui does not require the existence of `requirements.txt` but uses `install.py` to initialize the extension
https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Developing-extensions#installpy