### PR TITLE
Add build-essential package

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -30,7 +30,7 @@ RUN --mount=type=cache,target=/var/cache/apt \
   # we need those
   apt-get install -y fonts-dejavu-core rsync git jq moreutils aria2 \
   # extensions needs those
-  ffmpeg libglfw3-dev libgles2-mesa-dev pkg-config libcairo2 libcairo2-dev
+  ffmpeg libglfw3-dev libgles2-mesa-dev pkg-config libcairo2 libcairo2-dev build-essential
 
 
 RUN --mount=type=cache,target=/cache --mount=type=cache,target=/root/.cache/pip \


### PR DESCRIPTION
Fix the problem that some extensions need to be installed from src
Now, because the step of installing extensions is moved forward in `entrypoint.sh` instead of `startup.sh`, we cannot install some required packages before executing `install.py`
When installing the extension `sd-webui-roop`, it relies on `insightface==0.7.3`, and when installing this pypi package, it is found that when building the wheel package, an error will be reported because `gcc` cannot be found
https://github.com/s0md3v/sd-webui-roop/blob/ddc02ee1a914ba387fa338f9542ec16d128c56e5/requirements.txt#L1
Therefore, considering that not all pypi packages are distributed in wheel, those pypi packages distributed in src need `build-essential` to build