### PR TITLE
Comfy update and taesd and also medvram for a1111

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ x-base_service: &base_service
     ports:
       - "${WEBUI_PORT:-7860}:7860"
     volumes:
-      - &v1 ./data:/data
+      - &v1 /vat/backups/StableDiffusion/data:/data
       - &v2 ./output:/output
+      - ./models_on_nvme:/data/models/Stable-diffusion/nvme
     stop_signal: SIGKILL
     tty: true
     deploy:
@@ -31,7 +32,8 @@ services:
     build: ./services/AUTOMATIC1111
     image: sd-auto:62
     environment:
-      - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api
+      # - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api --distributed-remotes testrig_ftw3:192.168.1.41:7860 velka7:192.168.1.20:7860 --distributed-skip-verify-remotes --distributed-remotes-autosave --distributed-debug
+      - CLI_ARGS=--allow-code --xformers --enable-insecure-extension-access --api --listen
 
   auto-cpu:
     <<: *automatic
@@ -62,7 +64,7 @@ services:
     build: ./services/comfy/
     image: sd-comfy:3
     environment:
-      - CLI_ARGS=
+      - CLI_ARGS=--preview-method=taesd
 
 
   comfy-cpu:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,8 @@ x-base_service: &base_service
     ports:
       - "${WEBUI_PORT:-7860}:7860"
     volumes:
-      - &v1 /vat/backups/StableDiffusion/data:/data
+      - &v1 ./data:/data
       - &v2 ./output:/output
-      - ./models_on_nvme:/data/models/Stable-diffusion/nvme
     stop_signal: SIGKILL
     tty: true
     deploy:
@@ -32,8 +31,7 @@ services:
     build: ./services/AUTOMATIC1111
     image: sd-auto:62
     environment:
-      # - CLI_ARGS=--allow-code --medvram --xformers --enable-insecure-extension-access --api --distributed-remotes testrig_ftw3:192.168.1.41:7860 velka7:192.168.1.20:7860 --distributed-skip-verify-remotes --distributed-remotes-autosave --distributed-debug
-      - CLI_ARGS=--allow-code --xformers --enable-insecure-extension-access --api --listen
+      - CLI_ARGS=--allow-code --xformers --enable-insecure-extension-access --api
 
   auto-cpu:
     <<: *automatic

--- a/services/comfy/Dockerfile
+++ b/services/comfy/Dockerfile
@@ -22,6 +22,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 WORKDIR ${ROOT}
 
+ADD https://github.com/madebyollin/taesd/raw/main/taesd_decoder.pth \
+  ${ROOT}/models/vae_approx/taesd_decoder.pth
+ADD https://github.com/madebyollin/taesd/raw/main/taesdxl_decoder.pth \
+  ${ROOT}/models/vae_approx/taesdxl_decoder.pth
+
 # add info
 COPY . /docker/
 RUN cp /docker/extra_model_paths.yaml ${ROOT}

--- a/services/comfy/Dockerfile
+++ b/services/comfy/Dockerfile
@@ -10,12 +10,11 @@ RUN apt-get update && apt-get install -y git && apt-get clean
 
 ENV ROOT=/stable-diffusion
 RUN --mount=type=cache,target=/root/.cache/pip \
-  git clone https://github.com/comfyanonymous/ComfyUI.git ${ROOT} && \
+  git clone https://github.com/unphased/ComfyUI.git ${ROOT} && \
   cd ${ROOT} && \
   git checkout master && \
-  git reset --hard 884ea653c8d6fe19b3724f45a04a0d74cd881f2f && \
+  # git reset --hard 884ea653c8d6fe19b3724f45a04a0d74cd881f2f && \
   pip install -r requirements.txt
-
 
 RUN --mount=type=cache,target=/root/.cache/pip  \
   --mount=type=bind,from=xformers,source=/wheel.whl,target=/xformers-0.0.21-cp310-cp310-linux_x86_64.whl \
@@ -26,13 +25,18 @@ WORKDIR ${ROOT}
 
 ARG BRANCH=master SHA=8607c2d42d10b0108de02528e813cc703e58813f
 RUN --mount=type=cache,target=/root/.cache/pip \
+  ls -la models && \
+  ls -la models/vae_approx && \
   git fetch && \
   git checkout ${BRANCH} && \
-  git reset --hard ${SHA} && \
+  echo cach_bust 2 && \
+  git pull && \
+  # git reset --hard ${SHA} && \
   pip install -r requirements.txt
 
 # add info
 COPY . /docker/
+RUN ls -la /docker
 RUN cp /docker/extra_model_paths.yaml ${ROOT}
 
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/services/comfy/Dockerfile
+++ b/services/comfy/Dockerfile
@@ -8,27 +8,19 @@ ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
 
 RUN apt-get update && apt-get install -y git && apt-get clean
 
-ENV ROOT=/stable-diffusion
-RUN --mount=type=cache,target=/root/.cache/pip \
-  git clone https://github.com/unphased/ComfyUI.git ${ROOT} && \
-  cd ${ROOT} && \
-  git checkout master && \
-  # git reset --hard 884ea653c8d6fe19b3724f45a04a0d74cd881f2f && \
-  pip install -r requirements.txt
-
 RUN --mount=type=cache,target=/root/.cache/pip  \
   --mount=type=bind,from=xformers,source=/wheel.whl,target=/xformers-0.0.21-cp310-cp310-linux_x86_64.whl \
   pip install /xformers-0.0.21-cp310-cp310-linux_x86_64.whl
 
+ENV ROOT=/stable-diffusion
+RUN --mount=type=cache,target=/root/.cache/pip \
+  git clone https://github.com/comfyanonymous/ComfyUI.git ${ROOT} && \
+  cd ${ROOT} && \
+  git checkout master && \
+  git reset --hard 91ed2815d542c96fdad75edba2205140de3cbba6 && \
+  pip install -r requirements.txt
 
 WORKDIR ${ROOT}
-
-ARG BRANCH=master SHA=8607c2d42d10b0108de02528e813cc703e58813f
-RUN --mount=type=cache,target=/root/.cache/pip \
-  git fetch && \
-  git checkout ${BRANCH} && \
-  git reset --hard ${SHA} && \
-  pip install -r requirements.txt
 
 # add info
 COPY . /docker/

--- a/services/comfy/Dockerfile
+++ b/services/comfy/Dockerfile
@@ -25,18 +25,13 @@ WORKDIR ${ROOT}
 
 ARG BRANCH=master SHA=8607c2d42d10b0108de02528e813cc703e58813f
 RUN --mount=type=cache,target=/root/.cache/pip \
-  ls -la models && \
-  ls -la models/vae_approx && \
   git fetch && \
   git checkout ${BRANCH} && \
-  echo cach_bust 2 && \
-  git pull && \
-  # git reset --hard ${SHA} && \
+  git reset --hard ${SHA} && \
   pip install -r requirements.txt
 
 # add info
 COPY . /docker/
-RUN ls -la /docker
 RUN cp /docker/extra_model_paths.yaml ${ROOT}
 
 ENV NVIDIA_VISIBLE_DEVICES=all

--- a/services/comfy/extra_model_paths.yaml
+++ b/services/comfy/extra_model_paths.yaml
@@ -15,6 +15,7 @@ a111:
   gligen: models/GLIGEN
   clip: models/CLIPEncoder
   embeddings: embeddings
+  vae_approx: models/vae_approx
 
   custom_nodes: config/comfy/custom_nodes
 

--- a/services/comfy/extra_model_paths.yaml
+++ b/services/comfy/extra_model_paths.yaml
@@ -15,7 +15,6 @@ a111:
   gligen: models/GLIGEN
   clip: models/CLIPEncoder
   embeddings: embeddings
-  vae_approx: models/vae_approx
 
   custom_nodes: config/comfy/custom_nodes
 


### PR DESCRIPTION
<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->
A group of small improvements that I found: 

- ComfyUI bump version to current master
- Reduce weird repetitive steps in ComfyUI dockerfile (curious what the reason for checking out two commits was, previously. I kept the same reset --hard procedure but it's also not clear why not checkout the commit, or even just leave it at master, though that may break oneday but we will need to keep bumping it to keep it updated)
- Automate setting up TAESD preview, which seems like a no brainer default setting as it is a superior preview compared to the default. Regarding this, at first I set up a new entry in `services/comfy/extra_model_paths.yaml`, but then I realized I could just deliver the TAESD decoders via dockerfile.
- I took out the medvram flag from the a1111 args, I think we're keeping the instructions in wiki, so if we go ahead with this change we should add a note in the wiki saying if you have limited vram to manually add this flag. Because I find on my 3090's the use of medvram reduces speed significantly (16 it/s down to 10)


### Update versions

- comfy: https://github.com/comfyanonymous/ComfyUI/commit/91ed2815d542c96fdad75edba2205140de3cbba6
