### PR TITLE
Mount the plugin installation folder

### DIFF
--- a/services/comfy/entrypoint.sh
+++ b/services/comfy/entrypoint.sh
@@ -8,6 +8,7 @@ declare -A MOUNTS
 
 MOUNTS["/root/.cache"]="/data/.cache"
 MOUNTS["${ROOT}/input"]="/data/config/comfy/input"
+MOUNTS["${ROOT}/custom_nodes"]="/data/config/comfy/custom_nodes"
 MOUNTS["${ROOT}/output"]="/output/comfy"
 
 for to_path in "${!MOUNTS[@]}"; do


### PR DESCRIPTION
The plugin was installed but it was not mounted in the internal folder, so I added a script to mount it and it didn't seem to work properly without it.