### PR TITLE
Fix open_clip version issue

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -46,7 +46,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
   pip install pyngrok xformers \
   git+https://github.com/TencentARC/GFPGAN.git@8d2447a2d918f8eba5a4a01463fd48e45126a379 \
   git+https://github.com/openai/CLIP.git@d50d76daa670286dd6cacf3bcd80b5e4823fc8e1 \
-  git+https://github.com/mlfoundations/open_clip.git@bb6e834e9c70d9c27d0dc3ecedeebeaeb1ffad6b
+  git+https://github.com/mlfoundations/open_clip.git@bc247f6ece17d4bc6735739a7a8c5ce7d8ecd6a3
 
 
 COPY . /docker


### PR DESCRIPTION
fixes https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/615 by using hash of https://github.com/mlfoundations/open_clip/releases/tag/v2.23.0

"RuntimeError: Model config for ViT-bigG-14 not found."