### PR TITLE
Updated docker-compose to remove obsolete version syntax

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.9'
-
 x-base_service: &base_service
     ports:
       - "${WEBUI_PORT:-7860}:7860"


### PR DESCRIPTION
Removes `version:` syntax in `docker-compose` file. If left in, it throws an obsolete warning. I removed it from the docker-compose file to reduce unnecessary warnings and to keep the code up to current standards. 

See [Version top-level element (obsolete)](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-obsolete) for reference.