### PR TITLE
[docker]: update cuda-toolkit to v12.1 in `service/invoke/Dockerfile`

### DIFF
--- a/services/invoke/Dockerfile
+++ b/services/invoke/Dockerfile
@@ -3,7 +3,7 @@ RUN apk add --no-cache aria2
 RUN aria2c -x 5 --dir / --out wheel.whl 'https://github.com/AbdBarho/stable-diffusion-webui-docker/releases/download/6.0.0/xformers-0.0.21.dev544-cp310-cp310-manylinux2014_x86_64-pytorch201.whl'
 
 
-FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-devel
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_EXISTS_ACTION=w PIP_PREFER_BINARY=1
 


### PR DESCRIPTION
related bug: https://github.com/AbdBarho/stable-diffusion-webui-docker/issues/694

<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Should close issue #694

### Update versions

- auto-cuda-toolkit12+
