### PR TITLE
Fix cloning error in automatic1111 service dockerfile

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine/git:2.36.2 as download
 
 COPY clone.sh /clone.sh
 
+RUN git config --global http.version HTTP/1.1
+RUN git config --global http.postBuffer 157286400
+
 RUN . /clone.sh stable-diffusion-webui-assets https://github.com/AUTOMATIC1111/stable-diffusion-webui-assets.git 6f7db241d2f8ba7457bac5ca9753331f0c266917
 
 RUN . /clone.sh stable-diffusion-stability-ai https://github.com/Stability-AI/stablediffusion.git cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf \


### PR DESCRIPTION
Fix this error I got while cloning stability-ai repo
```
0.112 Initialized empty Git repository in /repositories/stable-diffusion-stability-ai/.git/
0.112 + git remote add origin https://github.com/Stability-AI/stablediffusion.git
0.113 + git fetch origin cf1d67a6fd5ea1aa600c4df58e5b47da45f6bdbf '--depth=1'
90.31 error: 1485 bytes of body are still expected
90.31 fetch-pack: unexpected disconnect while reading sideband packet
90.31 fatal: early EOF
90.31 fatal: fetch-pack: invalid index-pack output```

<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Closes issue #

### Update versions

- auto: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/
- invoke: https://github.com/invoke-ai/InvokeAI/commit/
- comfy: https://github.com/comfyanonymous/ComfyUI/commit/
