### PR TITLE
Install ComfyUI-Manager for easy plugin management in Comfy profile

### DIFF
--- a/services/comfy/Dockerfile
+++ b/services/comfy/Dockerfile
@@ -1,4 +1,4 @@
-FROM pytorch/pytorch:2.3.0-cuda12.1-cudnn8-runtime
+FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
 
@@ -6,11 +6,12 @@ RUN apt-get update && apt-get install -y git && apt-get clean
 
 ENV ROOT=/stable-diffusion
 RUN --mount=type=cache,target=/root/.cache/pip \
-  git clone https://github.com/comfyanonymous/ComfyUI.git ${ROOT} && \
+  git clone -b v0.3.10 --depth=1 https://github.com/comfyanonymous/ComfyUI.git ${ROOT} && \
   cd ${ROOT} && \
-  git checkout master && \
-  git reset --hard 276f8fce9f5a80b500947fb5745a4dde9e84622d && \
   pip install -r requirements.txt
+
+RUN git clone -b 3.6.5 --depth=1  https://github.com/ltdrdata/ComfyUI-Manager ${ROOT}/custom_nodes/comfyui-manager && \
+  pip install -r ${ROOT}/custom_nodes/comfyui-manager/requirements.txt
 
 WORKDIR ${ROOT}
 COPY . /docker/


### PR DESCRIPTION
Closes issue #711

Also updates ComfyUI to latest v0.3.10 release (nice new UI & performance upgrade), reduces git clone layer size by using shallow clone (`--depth 1`).

Also upgrade base Docker image to `FROM pytorch/pytorch:2.5.1-cuda12.4-cudnn9-runtime` whichs works succesfully as suggested in another PR also for latest GPU support :)