### PR TITLE
AUTOMATIC1111: Enable running as non root user.

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine/git:2.36.2 as download
-
 COPY clone.sh /clone.sh
+
 
 RUN . /clone.sh taming-transformers https://github.com/CompVis/taming-transformers.git 24268930bf1dce879235a7fddd0b2355b84d7ea6 \
   && rm -rf data assets **/*.ipynb
@@ -20,7 +20,6 @@ FROM alpine:3.17 as xformers
 RUN apk add --no-cache aria2
 RUN aria2c -x 5 --dir / --out wheel.whl 'https://github.com/AbdBarho/stable-diffusion-webui-docker/releases/download/6.0.0/xformers-0.0.21.dev544-cp310-cp310-manylinux2014_x86_64-pytorch201.whl'
 
-
 FROM python:3.10.9-slim
 
 ENV DEBIAN_FRONTEND=noninteractive PIP_PREFER_BINARY=1
@@ -30,15 +29,51 @@ RUN --mount=type=cache,target=/var/cache/apt \
   # we need those
   apt-get install -y fonts-dejavu-core rsync git jq moreutils aria2 \
   # extensions needs those
-  ffmpeg libglfw3-dev libgles2-mesa-dev pkg-config libcairo2 libcairo2-dev build-essential
+  ffmpeg libglfw3-dev libgles2-mesa-dev pkg-config libcairo2 libcairo2-dev build-essential \
+  # TODO: remove if fixed in A1111 (unlikely)
+  libgoogle-perftools-dev && apt-get clean
 
+ARG PUID=0
+ARG PGID=0
+ARG USER_HOME=/root
+# set build args as container environment variables for entrypoint reference
+ENV PUID=$PUID
+ENV PGID=$PGID
+ENV USER_HOME=$USER_HOME
+
+# if user home does not exist, create it
+RUN mkdir -p "$USER_HOME"
+
+# home already exists, chown it
+RUN chown -R "${PUID}:${PGID}" "$USER_HOME"
+
+# Only groupadd if we're non root
+RUN if [ "$PGID" -ne "0" ]; then \
+      echo non root group detected; \
+      groupadd \
+        --gid "$PGID" \
+        stablediffusion ;\
+    else \
+      echo "root group detected" ; \
+    fi
+
+# Only useradd if we're non root
+RUN if [ "$PUID" -ne "0" ]; then \
+      echo non root user detected; \
+      useradd \
+        --gid="$PGID" \
+        --no-user-group \
+        -M \
+        --home "$USER_HOME" \
+        stablediffusion ; \
+    else \
+      echo "root group detected" ; \
+    fi
 
 RUN --mount=type=cache,target=/cache --mount=type=cache,target=/root/.cache/pip \
   aria2c -x 5 --dir /cache --out torch-2.0.1-cp310-cp310-linux_x86_64.whl -c \
   https://download.pytorch.org/whl/cu118/torch-2.0.1%2Bcu118-cp310-cp310-linux_x86_64.whl && \
   pip install /cache/torch-2.0.1-cp310-cp310-linux_x86_64.whl torchvision --index-url https://download.pytorch.org/whl/cu118
-
-
 
 RUN --mount=type=cache,target=/root/.cache/pip \
   git clone https://github.com/AUTOMATIC1111/stable-diffusion-webui.git && \
@@ -50,10 +85,17 @@ RUN --mount=type=cache,target=/root/.cache/pip  \
   --mount=type=bind,from=xformers,source=/wheel.whl,target=/xformers-0.0.21.dev544-cp310-cp310-manylinux2014_x86_64.whl \
   pip install /xformers-0.0.21.dev544-cp310-cp310-manylinux2014_x86_64.whl
 
+# one of the ugliest hacks I ever wrote
+RUN  sed -i 's/in_app_dir = .*/in_app_dir = True/g' /usr/local/lib/python3.10/site-packages/gradio/routes.py
+
+RUN chown -R "$PUID:$PGID" /stable-diffusion-webui
+
+# drop permissions (if build targets non root)
+USER $PUID:$PGID
+
 ENV ROOT=/stable-diffusion-webui
 
-
-COPY --from=download /repositories/ ${ROOT}/repositories/
+COPY --from=download --chown=${PUID}:${PGID} /repositories/ ${ROOT}/repositories/
 RUN mkdir ${ROOT}/interrogate && cp ${ROOT}/repositories/clip-interrogator/data/* ${ROOT}/interrogate
 RUN --mount=type=cache,target=/root/.cache/pip \
   pip install -r ${ROOT}/repositories/CodeFormer/requirements.txt
@@ -67,8 +109,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # Note: don't update the sha of previous versions because the install will take forever
 # instead, update the repo state in a later step
 
-# TODO: either remove if fixed in A1111 (unlikely) or move to the top with other apt stuff
-RUN apt-get -y install libgoogle-perftools-dev && apt-get clean
 ENV LD_PRELOAD=libtcmalloc.so
 
 ARG SHA=394ffa7b0a7fff3ec484bcd084e673a8b301ccc8
@@ -78,13 +118,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
   git reset --hard ${SHA} && \
   pip install -r requirements_versions.txt
 
-COPY . /docker
+COPY --chown=$PUID:$PGID . /docker
 
 RUN \
   python3 /docker/info.py ${ROOT}/modules/ui.py && \
   mv ${ROOT}/style.css ${ROOT}/user.css && \
-  # one of the ugliest hacks I ever wrote \
-  sed -i 's/in_app_dir = .*/in_app_dir = True/g' /usr/local/lib/python3.10/site-packages/gradio/routes.py && \
   git config --global --add safe.directory '*'
 
 WORKDIR ${ROOT}

--- a/services/AUTOMATIC1111/entrypoint.sh
+++ b/services/AUTOMATIC1111/entrypoint.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -Eeuo pipefail
+RSYNC_FLAGS="${RSYNC_FLAGS:--a}"
 
 # TODO: move all mkdir -p ?
 mkdir -p /data/config/auto/scripts/
@@ -22,12 +23,12 @@ fi
 # copy models from original models folder
 mkdir -p /data/models/VAE-approx/ /data/models/karlo/
 
-rsync -a --info=NAME ${ROOT}/models/VAE-approx/ /data/models/VAE-approx/
-rsync -a --info=NAME ${ROOT}/models/karlo/ /data/models/karlo/
+rsync "$RSYNC_FLAGS" --info=NAME ${ROOT}/models/VAE-approx/ /data/models/VAE-approx/
+rsync "$RSYNC_FLAGS" --info=NAME ${ROOT}/models/karlo/ /data/models/karlo/
 
 declare -A MOUNTS
 
-MOUNTS["/root/.cache"]="/data/.cache"
+MOUNTS["${USER_HOME}/.cache"]="/data/.cache"
 MOUNTS["${ROOT}/models"]="/data/models"
 
 MOUNTS["${ROOT}/embeddings"]="/data/embeddings"
@@ -55,8 +56,8 @@ done
 echo "Installing extension dependencies (if any)"
 
 # because we build our container as root:
-chown -R root ~/.cache/
-chmod 766 ~/.cache/
+chown -R $PUID:$PGID ~/.cache/
+chmod 776 ~/.cache/
 
 shopt -s nullglob
 # For install.py, please refer to https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Developing-extensions#installpy


### PR DESCRIPTION
Expose build args to container which allow the web service
to run as given uid:gid.

By default, this behavior is "off". Building via docker compose still
defaults to root:root on everything. Unless these args are explicitly
set, no users should notice a difference.

Build arguments are also exposed as Docker environment variables, so they can
be freely referenced in the `entrypoint.sh`

Output files will be owned by PUID and PGID, so if set, no more root:root
images (unless desired).

New arguments:
  - ARG PUID=0
  - ARG PGID=0
  - ARG USER_HOME=/root

New environment variable:
  - RSYNC_FLAGS
    - NFS share doesn't like `-a` changing every bit on a directory

Example docker-compose.override.yaml using these flags

```
version: '3.9'

services:
  auto:
    environment:
      RSYNC_FLAGS: -vrlgotO
    build:
      args:
        USER_HOME: /opt/stablediffusion
        PUID: 1000
        PGID: 1002
    volumes:
      - /media/data:/data
      - /tmp:/output
  download:
    volumes:
      - /media/data:/data
```<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Closes issue #

### Update versions

- auto: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/
- invoke: https://github.com/invoke-ai/InvokeAI/commit/
- comfy: https://github.com/comfyanonymous/ComfyUI/commit/
