### PR TITLE
fix: upgrade typing_extensions to resolve altair import error

### DIFF
--- a/services/AUTOMATIC1111/Dockerfile
+++ b/services/AUTOMATIC1111/Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
   cd stable-diffusion-webui && \
   git reset --hard v1.9.4 && \
   pip install -r requirements_versions.txt
+  RUN pip install --upgrade typing_extensions
 
 
 ENV ROOT=/stable-diffusion-webui


### PR DESCRIPTION
Added RUN pip install --upgrade typing_extensions to ensure compatibility with altair and gradio dependencies. This resolves a startup crash caused by missing TypeIs in older versions of typing_extensions, allowing the container to initialize successfully.

<!--
Have you created an issue before opening a merge request???
https://github.com/AbdBarho/stable-diffusion-webui-docker#contributing
Please create one so we can discuss it, I don't want your effort to go to waste.
-->

Closes issue #

### Update versions

- auto: https://github.com/AUTOMATIC1111/stable-diffusion-webui/commit/
- invoke: https://github.com/invoke-ai/InvokeAI/commit/
- comfy: https://github.com/comfyanonymous/ComfyUI/commit/
